### PR TITLE
store key in pem format, instead of s-expression

### DIFF
--- a/client/client.ml
+++ b/client/client.ml
@@ -1,12 +1,10 @@
-let parse_key key =
-  let key = IO.with_in (Fpath.to_string key) (IO.read_all ?size:None) in
+let parse_key file =
+  let key = IO.with_in (Fpath.to_string file) (IO.read_all ?size:None) in
   let key =
-    try Mirage_crypto_pk.Rsa.priv_of_sexp (Sexplib.Sexp.of_string key) with
-      Sexplib0.Sexp_conv.Of_sexp_error _ ->
-      match X509.Private_key.decode_pem (Cstruct.of_string key) with
-      | Ok `RSA key -> key
-      | Ok _ -> failwith "unsupported key type, only RSA supported"
-      | Error `Msg m -> failwith ("error decoding key: " ^ m)
+    match X509.Private_key.decode_pem (Cstruct.of_string key) with
+    | Ok `RSA key -> key
+    | Ok _ -> failwith "unsupported key type, only RSA supported"
+    | Error `Msg m -> failwith ("error decoding key " ^ Fpath.to_string file ^ " (must be in PEM format): " ^ m)
   in
   Mirage_crypto_pk.Rsa.pub_of_priv key
 

--- a/client/dune
+++ b/client/dune
@@ -13,7 +13,6 @@
     uri
     lwt
     lwt.unix
-    sexplib
     cstruct
     oca_lib
     cmdliner

--- a/opam-health-check-ng.opam
+++ b/opam-health-check-ng.opam
@@ -27,8 +27,6 @@ depends: [
   "fmt" {>= "0.8.7"}
   "re" {>= "1.7.2"}
   "yaml" {>= "2.0.0"}
-  "sexplib" {>= "v0.9.0"}
-  "sexplib0" {>= "v0.9.0"}
   "xdg-basedir" {>= "0.0.4"}
   "dockerfile" {>= "8.2.0"}
   "current_ansi" {>= "0.1"}

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -126,12 +126,10 @@ let get_user_key workdir user =
   let keyfile = get_keyfile workdir user in
   let%lwt key = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string keyfile) (Lwt_io.read ?count:None) in
   Lwt.return
-    (try Mirage_crypto_pk.Rsa.priv_of_sexp (Sexplib.Sexp.of_string key) with
-       Sexplib0.Sexp_conv.Of_sexp_error _ ->
-       match X509.Private_key.decode_pem (Cstruct.of_string key) with
-       | Ok `RSA key -> key
-       | Ok _ -> failwith "unsupported key type, only RSA supported"
-       | Error `Msg m -> failwith ("error decoding key: " ^ m))
+    (match X509.Private_key.decode_pem (Cstruct.of_string key) with
+     | Ok `RSA key -> key
+     | Ok _ -> failwith "unsupported key type, only RSA supported"
+     | Error `Msg m -> failwith ("error decoding key for " ^ user ^ " (must be in PEM format): " ^ m))
 
 let partial_decrypt key msg =
   Cstruct.to_string (Mirage_crypto_pk.Rsa.decrypt ~key (Cstruct.of_string msg))

--- a/server/backend/dune
+++ b/server/backend/dune
@@ -14,8 +14,6 @@
     cohttp-lwt-unix
     docker_hub
     http-lwt-client
-    sexplib
-    sexplib0
     cstruct
     containers
     oca_server


### PR DESCRIPTION
We (well, @reynir https://github.com/mirage/mirage-crypto/pull/208#issuecomment-1969277758) noticed that opam-health-check uses the s-expression serialisation and deserialisation of RSA private keys (using mirage-crypto-pk).

The s-expression stuff is something we would like to remove in the next release.

Here's a PR that (a) encodes keys in the (standardized) pem format (using PKCS8), and (b) attempts to decode as pem and as s-expression. Thus using this PR, you'll be able to read old keys, but will always write new keys.

I'm not sure how widely opam-health-check-ng is deployed and how much of the client/server applications are spread -- but would a migration work for you? If you like, I can as well add an application / subcommand to convert the old s-expression key format to the new PEM format. WDYT?