### PR TITLE
Get rid of lwt_ppx and use Lwt.Syntax instead

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,6 @@
 (library
   (name oca_lib)
   (wrapped false)
-  (preprocess (pps lwt_ppx))
   (libraries
     unix
     lwt

--- a/lib/oca_lib.ml
+++ b/lib/oca_lib.ml
@@ -22,10 +22,10 @@ let char_is_docker_compatible = function
   | _ -> false
 
 let get_files dirname =
-  let%lwt dir = Lwt_unix.opendir (Fpath.to_string dirname) in
+  let* dir = Lwt_unix.opendir (Fpath.to_string dirname) in
   let rec aux files =
     try%lwt
-      let%lwt file = Lwt_unix.readdir dir in
+      let* file = Lwt_unix.readdir dir in
       if Fpath.is_rel_seg file then
         aux files
       else
@@ -33,18 +33,18 @@ let get_files dirname =
     with
     | End_of_file -> Lwt.return files
   in
-  let%lwt files = aux [] in
-  let%lwt () = Lwt_unix.closedir dir in
+  let* files = aux [] in
+  let* () = Lwt_unix.closedir dir in
   Lwt.return files
 
 let rec scan_dir ~full_path dirname =
-  let%lwt files = get_files full_path in
+  let* files = get_files full_path in
   Lwt_list.fold_left_s (fun acc file ->
     let full_path = Fpath.add_seg full_path file in
     let file = Fpath.normalize (Fpath.add_seg dirname file) in
     match%lwt Lwt_unix.stat (Fpath.to_string full_path) with
     | {Unix.st_kind = Unix.S_DIR; _} ->
-        let%lwt files = scan_dir ~full_path file in
+        let* files = scan_dir ~full_path file in
         Lwt.return (Fpath.to_string (Fpath.add_seg file "") :: files @ acc)
     | {Unix.st_kind = Unix.S_REG; _} ->
         Lwt.return (Fpath.to_string file :: acc)
@@ -71,7 +71,7 @@ let read_line_opt fd =
 
 let write fd str =
   let rec aux idx len =
-    let%lwt bytes_written = Lwt_unix.write_string fd str idx len in
+    let* bytes_written = Lwt_unix.write_string fd str idx len in
     match len - bytes_written with
     | 0 -> Lwt.return_unit
     | new_len -> aux (idx + bytes_written) new_len
@@ -82,7 +82,7 @@ let write_line fd str =
   write fd (str^"\n")
 
 let with_file flags mode filename f =
-  let%lwt fd = Lwt_unix.openfile filename flags mode in
+  let* fd = Lwt_unix.openfile filename flags mode in
   Lwt.finalize (fun () -> f fd) (fun () -> Lwt_unix.close fd)
 
 let exec ~timeout ~cidfile ~stdin ~stdout ~stderr cmd =
@@ -106,11 +106,11 @@ let exec ~timeout ~cidfile ~stdin ~stdout ~stderr cmd =
     (* NOTE: e.g. any processes shouldn't take more than 2 hours *)
     let timeout =
       let hours = timeout in
-      let%lwt () = Lwt_unix.sleep (hours *. 60.0 *. 60.0) in
+      let* () = Lwt_unix.sleep (hours *. 60.0 *. 60.0) in
       let cmd = String.concat " " cmd in
       (* TODO: show errors properly in stderr and on the debug console (same for the errors above) *)
       prerr_endline ("Command '"^cmd^"' timed-out ("^string_of_float hours^" hours)");
-      let%lwt () =
+      let* () =
         match cidfile with
         | None -> Lwt.return_unit
         | Some cidfile ->
@@ -132,7 +132,7 @@ let exec ~timeout ~cidfile ~stdin ~stdout ~stderr cmd =
 
 let pread ?cwd ?exit1 ~timeout cmd f =
   Lwt_process.with_process_in ?cwd ~timeout ~stdin:`Close ("", Array.of_list cmd) begin fun proc ->
-    let%lwt res = f proc#stdout in
+    let* res = f proc#stdout in
     match%lwt proc#close with
     | Unix.WEXITED n ->
         begin match n, exit1 with
@@ -191,7 +191,7 @@ let mkdir_p dir =
         Lwt.return_unit
     | x::xs ->
         let dir = Fpath.add_seg base x in
-        let%lwt [@ocaml.warning "-fragile-match"] () =
+        let* [@ocaml.warning "-fragile-match"] () =
           try%lwt
             Lwt_unix.mkdir (Fpath.to_string dir) 0o750
           with
@@ -204,15 +204,15 @@ let mkdir_p dir =
   | dirs -> aux (Fpath.v Filename.current_dir_name) dirs
 
 let rec rm_rf dirname =
-  let%lwt dir = Lwt_unix.opendir (Fpath.to_string dirname) in
+  let* dir = Lwt_unix.opendir (Fpath.to_string dirname) in
   begin
     let rec rm_files () =
       match%lwt Lwt_unix.readdir dir with
       | "." | ".." -> rm_files ()
       | file ->
           let file = dirname // file in
-          let%lwt stat = Lwt_unix.stat (Fpath.to_string file) in
-          let%lwt () =
+          let* stat = Lwt_unix.stat (Fpath.to_string file) in
+          let* () =
             match stat.Unix.st_kind with
             | Unix.S_DIR -> rm_rf file
             | Unix.S_REG -> Lwt_unix.unlink (Fpath.to_string file)
@@ -223,7 +223,7 @@ let rec rm_rf dirname =
     try%lwt rm_files () with End_of_file -> Lwt.return_unit
   end
   [%lwt.finally
-    let%lwt () = Lwt_unix.closedir dir in
+    let* () = Lwt_unix.closedir dir in
     Lwt_unix.rmdir (Fpath.to_string dirname)
   ]
 
@@ -236,7 +236,7 @@ let timer_log timer c msg =
   let start_time = !timer in
   let end_time = Unix.time () in
   let time_span = end_time -. start_time in
-  let%lwt () = write_line c ("Done. "^msg^" took: "^string_of_float time_span^" seconds") in
+  let* () = write_line c ("Done. "^msg^" took: "^string_of_float time_span^" seconds") in
   timer := Unix.time ();
   Lwt.return_unit
 

--- a/lib/oca_lib.ml
+++ b/lib/oca_lib.ml
@@ -42,7 +42,7 @@ let rec scan_dir ~full_path dirname =
   Lwt_list.fold_left_s (fun acc file ->
     let full_path = Fpath.add_seg full_path file in
     let file = Fpath.normalize (Fpath.add_seg dirname file) in
-    match%lwt Lwt_unix.stat (Fpath.to_string full_path) with
+    let* lwt = Lwt_unix.stat (Fpath.to_string full_path) in match lwt with
     | {Unix.st_kind = Unix.S_DIR; _} ->
         let* files = scan_dir ~full_path file in
         Lwt.return (Fpath.to_string (Fpath.add_seg file "") :: files @ acc)
@@ -58,7 +58,7 @@ let read_line_opt fd =
   let buffer = Buffer.create 256 in
   let tmp_buf = Bytes.create 1 in
   let rec aux () =
-    match%lwt Lwt_unix.read fd tmp_buf 0 1 with
+    let* lwt = Lwt_unix.read fd tmp_buf 0 1 in match lwt with
     | 0 -> Lwt.return None
     | 1 ->
         begin match Bytes.get tmp_buf 0 with
@@ -91,7 +91,7 @@ let exec ~timeout ~cidfile ~stdin ~stdout ~stderr cmd =
   (* TODO: maybe to factorize with pread below *)
   Lwt_process.with_process_none ~stdin ~stdout ~stderr ("", Array.of_list cmd) (fun proc ->
     let proc' =
-      match%lwt proc#close with
+      let* lwt = proc#close in match lwt with
       | Unix.WEXITED 0 ->
           Lwt.return (Ok ())
       | Unix.WEXITED n ->
@@ -133,7 +133,7 @@ let exec ~timeout ~cidfile ~stdin ~stdout ~stderr cmd =
 let pread ?cwd ?exit1 ~timeout cmd f =
   Lwt_process.with_process_in ?cwd ~timeout ~stdin:`Close ("", Array.of_list cmd) begin fun proc ->
     let* res = f proc#stdout in
-    match%lwt proc#close with
+    let* lwt = proc#close in match lwt with
     | Unix.WEXITED n ->
         begin match n, exit1 with
         | 0, _ ->
@@ -153,7 +153,7 @@ let pread ?cwd ?exit1 ~timeout cmd f =
 
 let read_unordered_lines c =
   let rec aux acc =
-    match%lwt Lwt_io.read_line_opt c with
+    let* lwt = Lwt_io.read_line_opt c in match lwt with
     | None -> Lwt.return acc (* Note: We don't care about the line ordering *)
     | Some line -> aux (line :: acc)
   in
@@ -207,7 +207,7 @@ let rec rm_rf dirname =
   let* dir = Lwt_unix.opendir (Fpath.to_string dirname) in
   begin
     let rec rm_files () =
-      match%lwt Lwt_unix.readdir dir with
+      let* lwt = Lwt_unix.readdir dir in match lwt with
       | "." | ".." -> rm_files ()
       | file ->
           let file = dirname // file in

--- a/lib/oca_lib.ml
+++ b/lib/oca_lib.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 let (//) = Fpath.(/)
 
 let with_atomic_file_out ~ext file f =
@@ -24,14 +26,18 @@ let char_is_docker_compatible = function
 let get_files dirname =
   let* dir = Lwt_unix.opendir (Fpath.to_string dirname) in
   let rec aux files =
-    try%lwt
-      let* file = Lwt_unix.readdir dir in
-      if Fpath.is_rel_seg file then
-        aux files
-      else
-        aux (file :: files)
-    with
-    | End_of_file -> Lwt.return files
+    Lwt.catch
+      begin fun () ->
+        let* file = Lwt_unix.readdir dir in
+        if Fpath.is_rel_seg file then
+          aux files
+        else
+          aux (file :: files)
+      end
+      begin function
+      | End_of_file -> Lwt.return files
+      | e -> raise e
+      end
   in
   let* files = aux [] in
   let* () = Lwt_unix.closedir dir in
@@ -115,10 +121,11 @@ let exec ~timeout ~cidfile ~stdin ~stdout ~stderr cmd =
         | None -> Lwt.return_unit
         | Some cidfile ->
             let container_id = IO.with_in cidfile (IO.read_all ~size:128) in
-            match%lwt
+            let* lwt =
               Lwt_process.exec ~stdin:`Close ~stdout:stderr ~stderr
                 ("", Array.of_list ["docker";"kill";"-s";"KILL";container_id])
-            with
+            in
+            match lwt with
             | Unix.WEXITED 0 -> Lwt.return ()
             | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
                 prerr_endline "docker kill failed";
@@ -191,11 +198,15 @@ let mkdir_p dir =
         Lwt.return_unit
     | x::xs ->
         let dir = Fpath.add_seg base x in
-        let* [@ocaml.warning "-fragile-match"] () =
-          try%lwt
-            Lwt_unix.mkdir (Fpath.to_string dir) 0o750
-          with
-          | Unix.Unix_error (Unix.EEXIST, _, _) -> Lwt.return_unit
+        let* () =
+          Lwt.catch
+            begin fun () ->
+              Lwt_unix.mkdir (Fpath.to_string dir) 0o750
+            end
+            begin function [@ocaml.warning "-fragile-match"]
+            | Unix.Unix_error (Unix.EEXIST, _, _) -> Lwt.return_unit
+            | e -> raise e
+            end
         in
         aux dir xs
   in
@@ -205,27 +216,28 @@ let mkdir_p dir =
 
 let rec rm_rf dirname =
   let* dir = Lwt_unix.opendir (Fpath.to_string dirname) in
-  begin
-    let rec rm_files () =
-      let* lwt = Lwt_unix.readdir dir in match lwt with
-      | "." | ".." -> rm_files ()
-      | file ->
-          let file = dirname // file in
-          let* stat = Lwt_unix.stat (Fpath.to_string file) in
-          let* () =
-            match stat.Unix.st_kind with
-            | Unix.S_DIR -> rm_rf file
-            | Unix.S_REG -> Lwt_unix.unlink (Fpath.to_string file)
-            | Unix.(S_CHR | S_BLK | S_LNK | S_FIFO | S_SOCK) -> assert false
-          in
-          rm_files ()
-    in
-    try%lwt rm_files () with End_of_file -> Lwt.return_unit
-  end
-  [%lwt.finally
-    let* () = Lwt_unix.closedir dir in
-    Lwt_unix.rmdir (Fpath.to_string dirname)
-  ]
+  Lwt.finalize
+    begin fun () ->
+      let rec rm_files () =
+        let* lwt = Lwt_unix.readdir dir in match lwt with
+        | "." | ".." -> rm_files ()
+        | file ->
+            let file = dirname // file in
+            let* stat = Lwt_unix.stat (Fpath.to_string file) in
+            let* () =
+              match stat.Unix.st_kind with
+              | Unix.S_DIR -> rm_rf file
+              | Unix.S_REG -> Lwt_unix.unlink (Fpath.to_string file)
+              | Unix.(S_CHR | S_BLK | S_LNK | S_FIFO | S_SOCK) -> assert false
+            in
+            rm_files ()
+      in
+      Lwt.catch (fun () -> rm_files ()) (function End_of_file -> Lwt.return_unit | e -> raise e)
+    end
+    begin fun () ->
+      let* () = Lwt_unix.closedir dir in
+      Lwt_unix.rmdir (Fpath.to_string dirname)
+    end
 
 type timer = float ref
 

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 type t = {
   yamlfile : Fpath.t;
   mutable name : string option;

--- a/lib/server_configfile.ml
+++ b/lib/server_configfile.ml
@@ -257,7 +257,7 @@ let set_ocaml_switches conf switches =
 
 let set_default_ocaml_switches conf f =
   if Option.is_none conf.ocaml_switches then
-    let%lwt x = f () in
+    let* x = f () in
     set_ocaml_switches conf x
   else
     Lwt.return_unit

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 type t = Fpath.t
 
 let (/) path file =

--- a/lib/server_workdirs.ml
+++ b/lib/server_workdirs.ml
@@ -28,7 +28,7 @@ let new_logdir ~compressed ~hash ~start_time workdir =
 
 let logdirs workdir =
   let base_logdir = base_logdir workdir in
-  let%lwt dirs = Oca_lib.get_files base_logdir in
+  let* dirs = Oca_lib.get_files base_logdir in
   let dirs = List.sort (fun x y -> -String.compare x y) dirs in
   let pool = Lwt_pool.create 32 (fun () -> Lwt.return_unit) in
   Lwt_list.map_p (fun dir ->
@@ -37,10 +37,10 @@ let logdirs workdir =
         let logdir = base_logdir/dir in
         begin match String.split_on_char '.' hash with
         | [hash] ->
-            let%lwt files = Lwt_pool.use pool (fun () -> Oca_lib.scan_dir logdir) in
+            let* files = Lwt_pool.use pool (fun () -> Oca_lib.scan_dir logdir) in
             Lwt.return (Logdir (Uncompressed, float_of_string time, hash, workdir, files))
         | [hash; "txz"] ->
-            let%lwt files = Lwt_pool.use pool (fun () -> Oca_lib.scan_tpxz_archive logdir) in
+            let* files = Lwt_pool.use pool (fun () -> Oca_lib.scan_tpxz_archive logdir) in
             Lwt.return (Logdir (Compressed, float_of_string time, hash, workdir, files))
         | _ -> assert false
         end
@@ -116,7 +116,7 @@ let logdir_move ~switches (Logdir (ty, _, _, workdir, _) as logdir) = match ty w
       let cwd = tmplogdir logdir in
       let directories = List.map Intf.Compiler.to_string switches in
       let archive = base_logdir workdir/get_logdir_name logdir+"txz" in
-      let%lwt () = Oca_lib.compress_tpxz_archive ~cwd ~directories archive in
+      let* () = Oca_lib.compress_tpxz_archive ~cwd ~directories archive in
       Oca_lib.rm_rf cwd
   | Uncompressed ->
       let tmplogdir = tmplogdir logdir in
@@ -154,23 +154,23 @@ let tmprevdepsfile ~pkg logdir = tmprevdepsdir logdir/pkg
 let configfile workdir = workdir/"config.yaml"
 
 let init_base workdir =
-  let%lwt () = Oca_lib.mkdir_p (keysdir workdir) in
-  let%lwt () = Oca_lib.mkdir_p (base_logdir workdir) in
-  let%lwt () = Oca_lib.mkdir_p (ilogdir workdir) in
-  let%lwt () = Oca_lib.mkdir_p (opamsdir workdir) in
+  let* () = Oca_lib.mkdir_p (keysdir workdir) in
+  let* () = Oca_lib.mkdir_p (base_logdir workdir) in
+  let* () = Oca_lib.mkdir_p (ilogdir workdir) in
+  let* () = Oca_lib.mkdir_p (opamsdir workdir) in
   Oca_lib.mkdir_p (revdepsdir workdir)
 
 let init_base_job ~switch logdir =
   let switch = Intf.Switch.name switch in
-  let%lwt () = Oca_lib.mkdir_p (tmpgooddir ~switch logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmppartialdir ~switch logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpbaddir ~switch logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpnotavailabledir ~switch logdir) in
+  let* () = Oca_lib.mkdir_p (tmpgooddir ~switch logdir) in
+  let* () = Oca_lib.mkdir_p (tmppartialdir ~switch logdir) in
+  let* () = Oca_lib.mkdir_p (tmpbaddir ~switch logdir) in
+  let* () = Oca_lib.mkdir_p (tmpnotavailabledir ~switch logdir) in
   Oca_lib.mkdir_p (tmpinternalfailuredir ~switch logdir)
 
 let init_base_jobs ~switches logdir =
-  let%lwt () = Oca_lib.mkdir_p (tmplogdir logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpmetadatadir logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmprevdepsdir logdir) in
-  let%lwt () = Oca_lib.mkdir_p (tmpopamsdir logdir) in
+  let* () = Oca_lib.mkdir_p (tmplogdir logdir) in
+  let* () = Oca_lib.mkdir_p (tmpmetadatadir logdir) in
+  let* () = Oca_lib.mkdir_p (tmprevdepsdir logdir) in
+  let* () = Oca_lib.mkdir_p (tmpopamsdir logdir) in
   Lwt_list.iter_s (fun switch -> init_base_job ~switch logdir) switches

--- a/opam-health-check-ng.opam
+++ b/opam-health-check-ng.opam
@@ -37,7 +37,6 @@ depends: [
   "github-unix"
   "github-data"
   "lwt"
-  "lwt_ppx"
   "uri"
   "docker_hub" {>= "0.2.0"}
   "memtrace"

--- a/opam-health-check-ng.opam
+++ b/opam-health-check-ng.opam
@@ -36,7 +36,7 @@ depends: [
   "github"
   "github-unix"
   "github-data"
-  "lwt"
+  "lwt" {>= "5.3.0"}
   "uri"
   "docker_hub" {>= "0.2.0"}
   "memtrace"

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 let ( // ) = Fpath.( / )
 
 let with_file_out ~flags file f =

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -26,7 +26,7 @@ let create_userkey workdir username =
 let create_admin_key workdir =
   let username = Oca_lib.default_admin_name in
   let keyfile = get_keyfile workdir username in
-  match%lwt Lwt_unix.file_exists (Fpath.to_string keyfile) with
+  let* lwt = Lwt_unix.file_exists (Fpath.to_string keyfile) in match lwt with
   | true -> Lwt.return_unit
   | false -> create_userkey workdir username
 

--- a/server/backend/admin.ml
+++ b/server/backend/admin.ml
@@ -32,27 +32,27 @@ let create_admin_key workdir =
 
 let get_log workdir =
   let ilogdir = Server_workdirs.ilogdir workdir in
-  let%lwt logs = Oca_lib.get_files ilogdir in
+  let* logs = Oca_lib.get_files ilogdir in
   let logs = List.sort String.compare logs in
   let logfile = Option.get_exn_or "no last log" (List.last_opt logs) in
   let logfile = ilogdir // logfile in
-  let%lwt fd = Lwt_unix.openfile (Fpath.to_string logfile) Unix.[O_RDONLY] 0o644 in
+  let* fd = Lwt_unix.openfile (Fpath.to_string logfile) Unix.[O_RDONLY] 0o644 in
   let off = ref 0 in
   let rec loop () =
     let is_running = Check.is_running () in
-    let%lwt new_off = Lwt_unix.lseek fd 0 Unix.SEEK_END in
+    let* new_off = Lwt_unix.lseek fd 0 Unix.SEEK_END in
     if new_off < 0 then
       assert false
     else if !off < new_off then begin
-      let%lwt _ = Lwt_unix.lseek fd !off Unix.SEEK_SET in
+      let* _ = Lwt_unix.lseek fd !off Unix.SEEK_SET in
       let len = new_off - !off in
       let buf = Bytes.create len in
-      let%lwt _ = Lwt_unix.read fd buf 0 len in
+      let* _ = Lwt_unix.read fd buf 0 len in
       off := new_off;
       Lwt.return (Some (Bytes.to_string buf))
     end else if is_running then begin
       off := new_off;
-      let%lwt () = Lwt_unix.sleep 1. in
+      let* () = Lwt_unix.sleep 1. in
       loop ()
     end else
       Lwt.return_none
@@ -60,17 +60,17 @@ let get_log workdir =
   Lwt.return loop
 
 let admin_action ~on_finished ~conf ~run_trigger workdir body =
-  let%lwt resp =
+  let* resp =
     match String.split_on_char '\n' body with
     | ["set-auto-run-interval"; i] ->
-        let%lwt () = Server_configfile.set_auto_run_interval conf (int_of_string i) in
+        let* () = Server_configfile.set_auto_run_interval conf (int_of_string i) in
         Lwt.return (fun () -> Lwt.return_none)
     | ["set-processes"; i] ->
         let i = int_of_string i in
         if i < 0 then
           Lwt.fail (Failure "Cannot set the number of processes to a negative value.")
         else
-          let%lwt () = Server_configfile.set_processes conf i in
+          let* () = Server_configfile.set_processes conf i in
           Lwt.return (fun () -> Lwt.return_none)
     | ["add-ocaml-switch";name;switch] ->
         let switch = Intf.Switch.create ~name ~switch in
@@ -79,36 +79,36 @@ let admin_action ~on_finished ~conf ~run_trigger workdir body =
           Lwt.fail (Failure "Cannot have duplicate switches names.")
         else
           let switches = List.sort Intf.Switch.compare (switch :: switches) in
-          let%lwt () = Server_configfile.set_ocaml_switches conf switches in
+          let* () = Server_configfile.set_ocaml_switches conf switches in
           Lwt.return (fun () -> Lwt.return_none)
     | ["set-ocaml-switch";name;switch] ->
         let switch = Intf.Switch.create ~name ~switch in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         let idx, _ = Option.get_exn_or "can't find switch name" (List.find_idx (Intf.Switch.equal switch) switches) in
         let switches = List.set_at_idx idx switch switches in
-        let%lwt () = Server_configfile.set_ocaml_switches conf switches in
+        let* () = Server_configfile.set_ocaml_switches conf switches in
         Lwt.return (fun () -> Lwt.return_none)
     | ["rm-ocaml-switch";name] ->
         let switch = Intf.Switch.create ~name ~switch:"(* TODO: remove this shit *)" in
         let switches = Option.get_or ~default:[] (Server_configfile.ocaml_switches conf) in
         let switches = List.remove ~eq:Intf.Switch.equal ~key:switch switches in
-        let%lwt () = Server_configfile.set_ocaml_switches conf switches in
+        let* () = Server_configfile.set_ocaml_switches conf switches in
         Lwt.return (fun () -> Lwt.return_none)
     | "set-slack-webhooks"::webhooks ->
         let webhooks = List.map Uri.of_string webhooks in
-        let%lwt () = Server_configfile.set_slack_webhooks conf webhooks in
+        let* () = Server_configfile.set_slack_webhooks conf webhooks in
         Lwt.return (fun () -> Lwt.return_none)
     | ["set-list-command";cmd] ->
-        let%lwt () = Server_configfile.set_list_command conf cmd in
+        let* () = Server_configfile.set_list_command conf cmd in
         Lwt.return (fun () -> Lwt.return_none)
     | ["run"] ->
-        let%lwt () = Lwt_mvar.put run_trigger () in
+        let* () = Lwt_mvar.put run_trigger () in
         Lwt.return (fun () -> Lwt.return_none)
     | ["add-user";username] ->
-        let%lwt () = create_userkey workdir username in
+        let* () = create_userkey workdir username in
         Lwt.return (fun () -> Lwt.return_none)
     | ["clear-cache"] ->
-        let%lwt () = on_finished workdir in
+        let* () = on_finished workdir in
         Lwt.return (fun () -> Lwt.return_none)
     | ["log"] ->
         get_log workdir
@@ -124,7 +124,7 @@ let is_bzero = function
 
 let get_user_key workdir user =
   let keyfile = get_keyfile workdir user in
-  let%lwt key = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string keyfile) (Lwt_io.read ?count:None) in
+  let* key = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string keyfile) (Lwt_io.read ?count:None) in
   Lwt.return
     (match X509.Private_key.decode_pem key with
      | Ok `RSA key -> key
@@ -143,14 +143,14 @@ let rec decrypt key msg =
     partial_decrypt key msg ^ decrypt key next
 
 let callback ~on_finished ~conf ~run_trigger workdir _conn _req body =
-  let%lwt body = Cohttp_lwt.Body.to_string body in
+  let* body = Cohttp_lwt.Body.to_string body in
   match String.Split.left ~by:"\n" body with
   | Some (pversion, body) when String.equal Oca_lib.protocol_version pversion ->
       begin match String.Split.left ~by:"\n" body with
       | Some (_, "") ->
           Lwt.fail (Failure "Empty message")
       | Some (user, body) ->
-          let%lwt key = get_user_key workdir user in
+          let* key = get_user_key workdir user in
           let body = decrypt key body in
           begin match String.Split.left ~by:"\n" body with
           | Some (user', body) when String.equal user user' ->

--- a/server/backend/backend.ml
+++ b/server/backend/backend.ml
@@ -35,19 +35,19 @@ let fill_pkgs_from_dir ~pool pkg_tbl logdir comp =
 
 let add_pkg full_name instances acc =
   let pkg = Intf.Pkg.name (Intf.Pkg.create ~full_name ~instances:[] ~opam:OpamFile.OPAM.empty ~revdeps:0) in (* TODO: Remove this horror *)
-  let%lwt acc = acc in
-  let%lwt opam = Oca_server.Cache.get_opam cache pkg in
-  let%lwt revdeps = Oca_server.Cache.get_revdeps cache full_name in
+  let* acc = acc in
+  let* opam = Oca_server.Cache.get_opam cache pkg in
+  let* revdeps = Oca_server.Cache.get_revdeps cache full_name in
   Lwt.return (Intf.Pkg.create ~full_name ~instances ~opam ~revdeps :: acc)
 
 let get_pkgs ~pool ~compilers logdir =
   let pkg_tbl = Pkg_tbl.create 10_000 in
   List.iter (fill_pkgs_from_dir ~pool pkg_tbl logdir) compilers;
-  let%lwt pkgs = Pkg_tbl.fold add_pkg pkg_tbl Lwt.return_nil in
+  let* pkgs = Pkg_tbl.fold add_pkg pkg_tbl Lwt.return_nil in
   Lwt.return (List.sort Intf.Pkg.compare pkgs)
 
 let get_log _ ~logdir ~comp ~state ~pkg =
-  let%lwt pkgs = Oca_server.Cache.get_pkgs ~logdir cache in
+  let* pkgs = Oca_server.Cache.get_pkgs ~logdir cache in
   match List.find_opt (fun p -> String.equal pkg (Intf.Pkg.full_name p)) pkgs with
   | None -> Lwt.return_none
   | Some pkg ->
@@ -58,17 +58,17 @@ let get_log _ ~logdir ~comp ~state ~pkg =
       match List.find_opt is_instance (Intf.Pkg.instances pkg) with
       | None -> Lwt.return_none
       | Some instance ->
-          let%lwt content = Intf.Instance.content instance in
+          let* content = Intf.Instance.content instance in
           Lwt.return (Some content)
 
 let get_opams workdir =
   let dir = Server_workdirs.opamsdir workdir in
-  let%lwt files = Oca_lib.get_files dir in
+  let* files = Oca_lib.get_files dir in
   let opams = Oca_server.Cache.Opams_cache.empty in
-  let%lwt opams =
+  let* opams =
     Lwt_list.fold_left_s begin fun opams pkg ->
       let file = Server_workdirs.opamfile ~pkg workdir in
-      let%lwt content = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string file) (Lwt_io.read ?count:None) in
+      let* content = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string file) (Lwt_io.read ?count:None) in
       let content = try OpamFile.OPAM.read_from_string content with _ -> OpamFile.OPAM.empty in
       Lwt.return (Oca_server.Cache.Opams_cache.add pkg content opams)
     end opams files
@@ -77,12 +77,12 @@ let get_opams workdir =
 
 let get_revdeps workdir =
   let dir = Server_workdirs.revdepsdir workdir in
-  let%lwt files = Oca_lib.get_files dir in
+  let* files = Oca_lib.get_files dir in
   let revdeps = Oca_server.Cache.Revdeps_cache.empty in
-  let%lwt revdeps =
+  let* revdeps =
     Lwt_list.fold_left_s begin fun revdeps pkg ->
       let file = Server_workdirs.revdepsfile ~pkg workdir in
-      let%lwt content = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string file) (Lwt_io.read ?count:None) in
+      let* content = Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string file) (Lwt_io.read ?count:None) in
       let content = String.split_on_char '\n' content in
       let content = List.hd content in
       let content = int_of_string content in
@@ -110,22 +110,22 @@ let cache_clear_and_init workdir =
 
 let run_action_loop ~conf ~run_trigger f =
   let rec loop () =
-    let%lwt () =
+    let* () =
       try%lwt
         let regular_run =
           let run_interval = Server_configfile.auto_run_interval conf * 60 * 60 in
           if run_interval > 0 then
-            let%lwt () = Lwt_unix.sleep (float_of_int run_interval) in
+            let* () = Lwt_unix.sleep (float_of_int run_interval) in
             Check.wait_current_run_to_finish ()
           else
             fst (Lwt.wait ())
         in
         let manual_run = Lwt_mvar.take run_trigger in
-        let%lwt () = Lwt.pick [regular_run; manual_run] in
+        let* () = Lwt.pick [regular_run; manual_run] in
         f ()
       with e ->
         let msg = Printexc.to_string e in
-        let%lwt () = Lwt_io.write_line Lwt_io.stderr ("Exception raised in action loop: "^msg) in
+        let* () = Lwt_io.write_line Lwt_io.stderr ("Exception raised in action loop: "^msg) in
         Lwt_io.write_line Lwt_io.stderr (Printexc.get_backtrace ())
     in
     loop ()
@@ -139,7 +139,7 @@ let start ~debug conf workdir =
   let callback = Admin.callback ~on_finished ~conf ~run_trigger workdir in
   Lwt.ignore_result (cache_clear_and_init workdir);
   Mirage_crypto_rng_unix.use_default ();
-  let%lwt () = Admin.create_admin_key workdir in
+  let* () = Admin.create_admin_key workdir in
   let task () =
     Lwt.join [
       tcp_server port callback;

--- a/server/backend/backend.ml
+++ b/server/backend/backend.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 type t = Server_workdirs.t
 
 let cache = Oca_server.Cache.create ()
@@ -111,22 +113,25 @@ let cache_clear_and_init workdir =
 let run_action_loop ~conf ~run_trigger f =
   let rec loop () =
     let* () =
-      try%lwt
-        let regular_run =
-          let run_interval = Server_configfile.auto_run_interval conf * 60 * 60 in
-          if run_interval > 0 then
-            let* () = Lwt_unix.sleep (float_of_int run_interval) in
-            Check.wait_current_run_to_finish ()
-          else
-            fst (Lwt.wait ())
-        in
-        let manual_run = Lwt_mvar.take run_trigger in
-        let* () = Lwt.pick [regular_run; manual_run] in
-        f ()
-      with e ->
-        let msg = Printexc.to_string e in
-        let* () = Lwt_io.write_line Lwt_io.stderr ("Exception raised in action loop: "^msg) in
-        Lwt_io.write_line Lwt_io.stderr (Printexc.get_backtrace ())
+      Lwt.catch
+        begin fun () ->
+          let regular_run =
+            let run_interval = Server_configfile.auto_run_interval conf * 60 * 60 in
+            if run_interval > 0 then
+              let* () = Lwt_unix.sleep (float_of_int run_interval) in
+              Check.wait_current_run_to_finish ()
+            else
+              fst (Lwt.wait ())
+          in
+          let manual_run = Lwt_mvar.take run_trigger in
+          let* () = Lwt.pick [regular_run; manual_run] in
+          f ()
+        end
+        begin fun e ->
+          let msg = Printexc.to_string e in
+          let* () = Lwt_io.write_line Lwt_io.stderr ("Exception raised in action loop: "^msg) in
+          Lwt_io.write_line Lwt_io.stderr (Printexc.get_backtrace ())
+        end
     in
     loop ()
   in

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -72,7 +72,7 @@ let docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout cmd =
         in
         let* () = Oca_lib.write_line fd base_dockerfile in
         let* () = Lwt_unix.close fd in
-        begin match%lwt proc with
+        begin let* lwt = proc in match lwt with
         | Ok () ->
             let* volumes =
               Lwt_list.fold_left_s (fun acc (volume, path, init) ->
@@ -121,10 +121,10 @@ let exec_out ~fexec ~fout =
 let docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~default c =
   let rec aux ~stdin =
     (* TODO: Use --progress=rawjson whenever it's available *)
-    match%lwt Oca_lib.read_line_opt stdin with
+    let* lwt = Oca_lib.read_line_opt stdin in match lwt with
     | Some "@@@OUTPUT" ->
         let rec aux acc =
-          match%lwt Oca_lib.read_line_opt stdin with
+          let* lwt = Oca_lib.read_line_opt stdin in match lwt with
           | Some "@@@OUTPUT" -> Lwt.return (List.rev acc)
           | Some x -> aux (x :: acc)
           | None -> prerr_endline (fmt "Error: Closing @@@OUTPUT could not be detected for command '%s'" c); Lwt.return []
@@ -155,7 +155,7 @@ let failure_kind conf ~pkg logfile =
   let timeout = Server_configfile.job_timeout conf in
   Lwt_io.with_file ~mode:Lwt_io.Input (Fpath.to_string logfile) begin fun ic ->
     let rec lookup res =
-      match%lwt Lwt_io.read_line_opt ic with
+      let* lwt = Lwt_io.read_line_opt ic in match lwt with
       | Some "+- The following actions failed" -> lookup `Failure
       | Some "+- The following actions were aborted" -> Lwt.return `Partial
       | Some line when String.equal ("[ERROR] No package named "^pkgname^" found.") line ||
@@ -227,7 +227,7 @@ let run_job ~conf ~max_ram_per_job ~pool ~stderr ~base_dockerfile ~switch ~num l
         let* () = Oca_lib.write_line stderr ("["^num^"] succeeded.") in
         Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpgoodlog ~pkg ~switch logdir))
     | Error () ->
-        begin match%lwt failure_kind conf ~pkg logfile with
+        begin let* lwt = failure_kind conf ~pkg logfile in match lwt with
         | `Partial ->
             let* () = Oca_lib.write_line stderr ("["^num^"] finished with a partial failure.") in
             Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmppartiallog ~pkg ~switch logdir))
@@ -553,7 +553,7 @@ let update_docker_image conf =
       Docker_hub.Token.fetch name >>!=
       Docker_hub.Manifests.fetch tag
     in
-    match%lwt manifests with
+    let* lwt = manifests in match lwt with
     | Ok manifests ->
         let elements = Docker_hub.Manifests.elements manifests in
         begin match List.find_opt is_correct_platform elements with
@@ -579,12 +579,12 @@ let update_docker_image conf =
   match String.split_on_char '@' image with
   | [] -> assert false
   | [image] ->
-      begin match%lwt get_latest_image ~image with
+      begin let* lwt = get_latest_image ~image in match lwt with
       | Some image -> Server_configfile.set_platform_image conf image
       | None -> Lwt.fail (Failure (fmt "Could not get digest for image '%s'" image))
       end
   | [image; _old_digest] ->
-      begin match%lwt get_latest_image ~image with
+      begin let* lwt = get_latest_image ~image in match lwt with
       | Some image -> Server_configfile.set_platform_image conf image
       | None -> prerr_endline "Defaulting to old digest"; Lwt.return_unit
       end

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 let fmt = Printf.sprintf
 let ( // ) = Filename.concat
 let ( >>!= ) = Lwt_result.bind
@@ -77,10 +79,11 @@ let docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout cmd =
             let* volumes =
               Lwt_list.fold_left_s (fun acc (volume, path, init) ->
                 let volume = ["--volume";volume^":"^path] in
-                match%lwt
+                let* lwt =
                   Oca_lib.exec ~timeout ~stdin:`Close ~stdout ~stderr:stdout ~cidfile:None
                     (["docker";"run";"--memory";max_ram_per_job;"--rm"]@volume@[tag;"sh";"-c";init])
-                with
+                in
+                match lwt with
                 | Ok () -> Lwt.return (acc @ volume)
                 | Error () -> failwith "volume creation failed"
               ) [] (volumes ~conf)
@@ -112,7 +115,7 @@ let docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout cmd =
 
 let exec_out ~fexec ~fout =
   let stdin, stdout = Lwt_unix.pipe () in
-  let proc = (fexec ~stdout) [%lwt.finally Lwt_unix.close stdout] in
+  let proc = Lwt.finalize (fun () -> fexec ~stdout) (fun () -> Lwt_unix.close stdout) in
   let* res = fout ~stdin in
   let* () = Lwt_unix.close stdin in
   let* r = proc in
@@ -135,11 +138,12 @@ let docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~def
         aux ~stdin
     | None -> Lwt.return_nil
   in
-  match%lwt
+  let* lwt =
     exec_out ~fout:aux ~fexec:(fun ~stdout ->
       docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout (fmt "echo '%f' > /dev/null && echo @@@OUTPUT && %s && echo @@@OUTPUT" (Unix.time ()) c)
     )
-  with
+  in
+  match lwt with
   | (Ok (), r) ->
       Lwt.return r
   | (Error (), _) ->
@@ -218,11 +222,12 @@ let run_job ~conf ~max_ram_per_job ~pool ~stderr ~base_dockerfile ~switch ~num l
     let* () = Oca_lib.write_line stderr ("["^num^"] Checking "^pkg^" on "^Intf.Switch.switch switch^"…") in
     let switch = Intf.Switch.name switch in
     let logfile = Server_workdirs.tmplogfile ~pkg ~switch logdir in
-    match%lwt
+    let* lwt =
       Oca_lib.with_file Unix.[O_WRONLY; O_CREAT; O_TRUNC] 0o640 (Fpath.to_string logfile) (fun stdout ->
         docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout (run_script ~conf pkg)
       )
-    with
+    in
+    match lwt with
     | Ok () ->
         let* () = Oca_lib.write_line stderr ("["^num^"] succeeded.") in
         Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpgoodlog ~pkg ~switch logdir))
@@ -506,7 +511,7 @@ let trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf =
   Server_configfile.slack_webhooks conf |>
   Lwt_list.iter_s begin fun webhook ->
     let* () = Oca_lib.write_line stderr ("Triggering Slack webhook "^Uri.to_string webhook) in
-    match%lwt
+    let* lwt =
       Http_lwt_client.request
         ~config:(`HTTP_1_1 Httpaf.Config.default) (* TODO: Remove this when https://github.com/roburio/http-lwt-client/issues/7 is fixed *)
         ~meth:`POST
@@ -514,7 +519,8 @@ let trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf =
         ~body
         (Uri.to_string webhook)
         (fun _resp acc x -> Lwt.return (acc ^ x)) ""
-    with
+    in
+    match lwt with
     | Ok ({Http_lwt_client.status = `OK; _}, _body) -> Lwt.return_unit
     | Ok (resp, body) ->
         let resp = Format.sprintf "%a" Http_lwt_client.pp_response resp in
@@ -604,53 +610,56 @@ let run ~debug ~on_finished ~conf cache workdir =
   Lwt.async begin fun () -> Lwt.finalize begin fun () ->
     let start_time = Unix.time () in
     with_stderr ~start_time workdir begin fun ~stderr ->
-      try%lwt
-        let timer = Oca_lib.timer_start () in
-        let* () = update_docker_image conf in
-        let* (opam_repo, opam_repo_commit) = get_commit_hash_default conf in
-        let* extra_repos = get_commit_hash_extra_repos conf in
-        let* () =
-          (* TODO: Add a mutex system to make sure nobody else is using docker
-             at the same time (e.g. another opam-health-check instance) *)
-          match%lwt
-            Oca_lib.exec ~timeout:1.0 ~stdin:`Close ~stdout:stderr ~stderr ~cidfile:None
-              ["docker";"system";"prune";"-af"]
-          with
-          | Ok () -> Lwt.return_unit
-          | Error () -> raise (Failure "docker prune failed")
-        in
-        let switches' = switches in
-        let switches = List.map (fun switch -> (switch, get_dockerfile ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch)) switches in
-        begin match switches with
-        | switch::_ ->
-            let* old_logdir = Oca_server.Cache.get_logdirs cache in
-            let compressed = Server_configfile.enable_logs_compression conf in
-            let old_logdir = List.head_opt old_logdir in
-            let new_logdir = Server_workdirs.new_logdir ~compressed ~hash:opam_repo_commit ~start_time workdir in
-            let* () = Server_workdirs.init_base_jobs ~switches:switches' new_logdir in
-            let number_of_jobs = Server_configfile.processes conf in
-            let pool = Lwt_pool.create number_of_jobs (fun () -> Lwt.return_unit) in
-            let max_ram_per_job = get_max_ram_per_job ~number_of_jobs in
-            let* pkgs = Lwt_list.map_s (get_pkgs ~debug ~max_ram_per_job ~stderr ~conf) switches in
-            let pkgs = Pkg_set.of_list (List.concat pkgs) in
-            let* () = Oca_lib.timer_log timer stderr "Initialization" in
-            let (_, jobs) = run_jobs ~conf ~max_ram_per_job ~pool ~stderr new_logdir switches pkgs in
-            let (_, jobs) = get_metadata ~debug ~conf ~max_ram_per_job ~jobs ~pool ~stderr new_logdir switch pkgs in
-            let* () = Lwt.join jobs in
-            let* () = Oca_lib.timer_log timer stderr "Operation" in
-            let* () = Oca_lib.write_line stderr "Finishing up…" in
-            let* () = move_tmpdirs_to_final ~switches:switches' new_logdir workdir in
-            let* () = on_finished workdir in
-            let* () = trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf in
-            Oca_lib.timer_log timer stderr "Clean up"
-        | [] ->
-            Oca_lib.write_line stderr "No switches."
+      Lwt.catch
+        begin fun () ->
+          let timer = Oca_lib.timer_start () in
+          let* () = update_docker_image conf in
+          let* (opam_repo, opam_repo_commit) = get_commit_hash_default conf in
+          let* extra_repos = get_commit_hash_extra_repos conf in
+          let* () =
+            (* TODO: Add a mutex system to make sure nobody else is using docker
+               at the same time (e.g. another opam-health-check instance) *)
+            let* lwt =
+              Oca_lib.exec ~timeout:1.0 ~stdin:`Close ~stdout:stderr ~stderr ~cidfile:None
+                ["docker";"system";"prune";"-af"]
+            in
+            match lwt with
+            | Ok () -> Lwt.return_unit
+            | Error () -> raise (Failure "docker prune failed")
+          in
+          let switches' = switches in
+          let switches = List.map (fun switch -> (switch, get_dockerfile ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch)) switches in
+          begin match switches with
+          | switch::_ ->
+              let* old_logdir = Oca_server.Cache.get_logdirs cache in
+              let compressed = Server_configfile.enable_logs_compression conf in
+              let old_logdir = List.head_opt old_logdir in
+              let new_logdir = Server_workdirs.new_logdir ~compressed ~hash:opam_repo_commit ~start_time workdir in
+              let* () = Server_workdirs.init_base_jobs ~switches:switches' new_logdir in
+              let number_of_jobs = Server_configfile.processes conf in
+              let pool = Lwt_pool.create number_of_jobs (fun () -> Lwt.return_unit) in
+              let max_ram_per_job = get_max_ram_per_job ~number_of_jobs in
+              let* pkgs = Lwt_list.map_s (get_pkgs ~debug ~max_ram_per_job ~stderr ~conf) switches in
+              let pkgs = Pkg_set.of_list (List.concat pkgs) in
+              let* () = Oca_lib.timer_log timer stderr "Initialization" in
+              let (_, jobs) = run_jobs ~conf ~max_ram_per_job ~pool ~stderr new_logdir switches pkgs in
+              let (_, jobs) = get_metadata ~debug ~conf ~max_ram_per_job ~jobs ~pool ~stderr new_logdir switch pkgs in
+              let* () = Lwt.join jobs in
+              let* () = Oca_lib.timer_log timer stderr "Operation" in
+              let* () = Oca_lib.write_line stderr "Finishing up…" in
+              let* () = move_tmpdirs_to_final ~switches:switches' new_logdir workdir in
+              let* () = on_finished workdir in
+              let* () = trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf in
+              Oca_lib.timer_log timer stderr "Clean up"
+          | [] ->
+              Oca_lib.write_line stderr "No switches."
+          end
         end
-      with
-      | exc ->
+        begin fun exc ->
           let* () = Oca_lib.write_line stderr ("Exception: "^Printexc.to_string exc^".") in
           let* () = Oca_lib.write stderr (Printexc.get_backtrace ()) in
           Lwt.return (prerr_endline "The current run failed unexpectedly. Please check the latest log using: opam-health-check log")
+        end
     end
   end (fun () -> run_locked := false; Lwt.return_unit) end;
   Lwt.return_unit

--- a/server/backend/check.ml
+++ b/server/backend/check.ml
@@ -58,7 +58,7 @@ let docker_img_hashtbl = Docker_img_hashtbl.create 1
 let docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout cmd =
   let base_dockerfile = Format.sprintf "%a" Dockerfile.pp base_dockerfile in
   let timeout = Server_configfile.job_timeout conf in
-  let%lwt tag, volumes =
+  let* tag, volumes =
     match Docker_img_hashtbl.find_opt docker_img_hashtbl base_dockerfile with
     | None ->
         let dockerfile_hash = String.hash base_dockerfile in
@@ -70,11 +70,11 @@ let docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout cmd =
           Oca_lib.exec ~timeout ~stdin ~stdout ~stderr:stdout ~cidfile:None
             ["docker";"buildx";"build";"--progress=plain";"-t";tag;"-"]
         in
-        let%lwt () = Oca_lib.write_line fd base_dockerfile in
-        let%lwt () = Lwt_unix.close fd in
+        let* () = Oca_lib.write_line fd base_dockerfile in
+        let* () = Lwt_unix.close fd in
         begin match%lwt proc with
         | Ok () ->
-            let%lwt volumes =
+            let* volumes =
               Lwt_list.fold_left_s (fun acc (volume, path, init) ->
                 let volume = ["--volume";volume^":"^path] in
                 match%lwt
@@ -106,16 +106,16 @@ let docker_build ~conf ~max_ram_per_job ~base_dockerfile ~stdout cmd =
     Oca_lib.exec ~timeout ~stdin ~stdout ~stderr:stdout ~cidfile:(Some cidfile)
       (["docker";"run";"--rm";"--memory";max_ram_per_job;"--network=none";"--cidfile";cidfile]@volumes@["-i";tag])
   in
-  let%lwt () = Oca_lib.write_line fd cmd in
-  let%lwt () = Lwt_unix.close fd in
+  let* () = Oca_lib.write_line fd cmd in
+  let* () = Lwt_unix.close fd in
   proc
 
 let exec_out ~fexec ~fout =
   let stdin, stdout = Lwt_unix.pipe () in
   let proc = (fexec ~stdout) [%lwt.finally Lwt_unix.close stdout] in
-  let%lwt res = fout ~stdin in
-  let%lwt () = Lwt_unix.close stdin in
-  let%lwt r = proc in
+  let* res = fout ~stdin in
+  let* () = Lwt_unix.close stdin in
+  let* r = proc in
   Lwt.return (r, res)
 
 let docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~default c =
@@ -131,7 +131,7 @@ let docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~def
         in
         aux []
     | Some line ->
-        let%lwt () = (if debug then Oca_lib.write_line stderr line else Lwt.return_unit) in
+        let* () = (if debug then Oca_lib.write_line stderr line else Lwt.return_unit) in
         aux ~stdin
     | None -> Lwt.return_nil
   in
@@ -215,7 +215,7 @@ exit $res
 
 let run_job ~conf ~max_ram_per_job ~pool ~stderr ~base_dockerfile ~switch ~num logdir pkg =
   Lwt_pool.use pool begin fun () ->
-    let%lwt () = Oca_lib.write_line stderr ("["^num^"] Checking "^pkg^" on "^Intf.Switch.switch switch^"…") in
+    let* () = Oca_lib.write_line stderr ("["^num^"] Checking "^pkg^" on "^Intf.Switch.switch switch^"…") in
     let switch = Intf.Switch.name switch in
     let logfile = Server_workdirs.tmplogfile ~pkg ~switch logdir in
     match%lwt
@@ -224,21 +224,21 @@ let run_job ~conf ~max_ram_per_job ~pool ~stderr ~base_dockerfile ~switch ~num l
       )
     with
     | Ok () ->
-        let%lwt () = Oca_lib.write_line stderr ("["^num^"] succeeded.") in
+        let* () = Oca_lib.write_line stderr ("["^num^"] succeeded.") in
         Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpgoodlog ~pkg ~switch logdir))
     | Error () ->
         begin match%lwt failure_kind conf ~pkg logfile with
         | `Partial ->
-            let%lwt () = Oca_lib.write_line stderr ("["^num^"] finished with a partial failure.") in
+            let* () = Oca_lib.write_line stderr ("["^num^"] finished with a partial failure.") in
             Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmppartiallog ~pkg ~switch logdir))
         | `Failure ->
-            let%lwt () = Oca_lib.write_line stderr ("["^num^"] failed.") in
+            let* () = Oca_lib.write_line stderr ("["^num^"] failed.") in
             Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpbadlog ~pkg ~switch logdir))
         | `NotAvailable ->
-            let%lwt () = Oca_lib.write_line stderr ("["^num^"] finished with not available.") in
+            let* () = Oca_lib.write_line stderr ("["^num^"] finished with not available.") in
             Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpnotavailablelog ~pkg ~switch logdir))
         | `Other | `AcceptFailures | `Timeout ->
-            let%lwt () = Oca_lib.write_line stderr ("["^num^"] finished with an internal failure.") in
+            let* () = Oca_lib.write_line stderr ("["^num^"] finished with an internal failure.") in
             Lwt_unix.rename (Fpath.to_string logfile) (Fpath.to_string (Server_workdirs.tmpinternalfailurelog ~pkg ~switch logdir))
         end
   end
@@ -327,8 +327,8 @@ let get_dockerfile ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch =
 
 let get_pkgs ~debug ~conf ~max_ram_per_job ~stderr (switch, base_dockerfile) =
   let switch = Intf.Compiler.to_string (Intf.Switch.name switch) in
-  let%lwt () = Oca_lib.write_line stderr ("Getting packages list for "^switch^"… (this may take an hour or two)") in
-  let%lwt pkgs = docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~default:None (Server_configfile.list_command conf) in
+  let* () = Oca_lib.write_line stderr ("Getting packages list for "^switch^"… (this may take an hour or two)") in
+  let* pkgs = docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~default:None (Server_configfile.list_command conf) in
   let pkgs = List.filter begin fun pkg ->
     Oca_lib.is_valid_filename pkg &&
     match Intf.Pkg.name (Intf.Pkg.create ~full_name:pkg ~instances:[] ~opam:OpamFile.OPAM.empty ~revdeps:0) with (* TODO: Remove this horror *)
@@ -392,11 +392,11 @@ let get_pkgs ~debug ~conf ~max_ram_per_job ~stderr (switch, base_dockerfile) =
     | _ -> true
   end pkgs in
   let nelts = string_of_int (List.length pkgs) in
-  let%lwt () = Oca_lib.write_line stderr ("Package list for "^switch^" retrieved. "^nelts^" elements to process.") in
+  let* () = Oca_lib.write_line stderr ("Package list for "^switch^" retrieved. "^nelts^" elements to process.") in
   Lwt.return pkgs
 
 let with_stderr ~start_time workdir f =
-  let%lwt () = Oca_lib.mkdir_p (Server_workdirs.ilogdir workdir) in
+  let* () = Oca_lib.mkdir_p (Server_workdirs.ilogdir workdir) in
   let logfile = Server_workdirs.new_ilogfile ~start_time workdir in
   Oca_lib.with_file Unix.[O_WRONLY; O_CREAT; O_APPEND] 0o640 (Fpath.to_string logfile) (fun stderr -> f ~stderr)
 
@@ -409,7 +409,7 @@ let revdeps_script pkg =
 
 let get_metadata ~debug ~conf ~max_ram_per_job ~jobs ~pool ~stderr logdir (_, base_dockerfile) pkgs =
   let get_revdeps ~base_dockerfile ~pkgname ~pkg ~logdir =
-    let%lwt revdeps = docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~default:(Some []) (revdeps_script pkg) in
+    let* revdeps = docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~default:(Some []) (revdeps_script pkg) in
     let module Set = Set.Make(String) in
     let revdeps = Set.of_list revdeps in
     let revdeps = Set.remove pkgname revdeps in (* https://github.com/ocaml/opam/issues/4446 *)
@@ -418,7 +418,7 @@ let get_metadata ~debug ~conf ~max_ram_per_job ~jobs ~pool ~stderr logdir (_, ba
     )
   in
   let get_latest_metadata ~base_dockerfile ~pkgname ~logdir = (* TODO: Get this locally by merging all the repository and parsing the opam files using opam-core *)
-    let%lwt opam =
+    let* opam =
       docker_build_str ~debug ~conf ~max_ram_per_job ~base_dockerfile ~stderr ~default:(Some [])
         ("opam show --raw "^Filename.quote pkgname)
     in
@@ -430,8 +430,8 @@ let get_metadata ~debug ~conf ~max_ram_per_job ~jobs ~pool ~stderr logdir (_, ba
     let pkgname = Intf.Pkg.name (Intf.Pkg.create ~full_name ~instances:[] ~opam:OpamFile.OPAM.empty ~revdeps:0) in (* TODO: Remove this horror *)
     let job =
       Lwt_pool.use pool begin fun () ->
-        let%lwt () = Oca_lib.write_line stderr ("Getting metadata for "^full_name) in
-        let%lwt () = get_revdeps ~base_dockerfile ~pkgname ~pkg:full_name ~logdir in
+        let* () = Oca_lib.write_line stderr ("Getting metadata for "^full_name) in
+        let* () = get_revdeps ~base_dockerfile ~pkgname ~pkg:full_name ~logdir in
         if Pkg_set.mem pkgname pkgs_set then Lwt.return_unit else get_latest_metadata ~base_dockerfile ~pkgname ~logdir
       end
     in
@@ -442,7 +442,7 @@ let get_commit_hash github =
   let user = Intf.Github.user github in
   let repo = Intf.Github.repo github in
   let branch = Intf.Github.branch github in
-  let%lwt r =
+  let* r =
     Github.Monad.run begin
       let ( >>= ) = Github.Monad.( >>= ) in
       Github.Repo.info ~user ~repo () >>= fun info ->
@@ -459,13 +459,13 @@ let get_commit_hash github =
 
 let get_commit_hash_default conf =
   let github = Server_configfile.default_repository conf in
-  let%lwt hash = get_commit_hash github in
+  let* hash = get_commit_hash github in
   Lwt.return (github, hash)
 
 let get_commit_hash_extra_repos conf =
   Lwt_list.map_s begin fun repository ->
     let github = Intf.Repository.github repository in
-    let%lwt hash = get_commit_hash github in
+    let* hash = get_commit_hash github in
     Lwt.return (repository, hash)
   end (Server_configfile.extra_repositories conf)
 
@@ -474,9 +474,9 @@ let move_tmpdirs_to_final ~switches logdir workdir =
   let tmpmetadatadir = Server_workdirs.tmpmetadatadir logdir in
   let tmpdir = Server_workdirs.tmpdir logdir in
   let switches = List.map Intf.Switch.name switches in
-  let%lwt () = Server_workdirs.logdir_move ~switches logdir in
-  let%lwt () = Oca_lib.rm_rf metadatadir in
-  let%lwt () = Lwt_unix.rename (Fpath.to_string tmpmetadatadir) (Fpath.to_string metadatadir) in
+  let* () = Server_workdirs.logdir_move ~switches logdir in
+  let* () = Oca_lib.rm_rf metadatadir in
+  let* () = Lwt_unix.rename (Fpath.to_string tmpmetadatadir) (Fpath.to_string metadatadir) in
   Oca_lib.rm_rf tmpdir
 
 let run_jobs ~conf ~max_ram_per_job ~pool ~stderr logdir switches pkgs =
@@ -505,7 +505,7 @@ let trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf =
   in
   Server_configfile.slack_webhooks conf |>
   Lwt_list.iter_s begin fun webhook ->
-    let%lwt () = Oca_lib.write_line stderr ("Triggering Slack webhook "^Uri.to_string webhook) in
+    let* () = Oca_lib.write_line stderr ("Triggering Slack webhook "^Uri.to_string webhook) in
     match%lwt
       Http_lwt_client.request
         ~config:(`HTTP_1_1 Httpaf.Config.default) (* TODO: Remove this when https://github.com/roburio/http-lwt-client/issues/7 is fixed *)
@@ -529,7 +529,7 @@ let is_running () = !run_locked
 let wait_current_run_to_finish =
   let rec loop () =
     if is_running () then
-      let%lwt () = Lwt_unix.sleep 1. in
+      let* () = Lwt_unix.sleep 1. in
       loop ()
     else
       Lwt.return_unit
@@ -606,10 +606,10 @@ let run ~debug ~on_finished ~conf cache workdir =
     with_stderr ~start_time workdir begin fun ~stderr ->
       try%lwt
         let timer = Oca_lib.timer_start () in
-        let%lwt () = update_docker_image conf in
-        let%lwt (opam_repo, opam_repo_commit) = get_commit_hash_default conf in
-        let%lwt extra_repos = get_commit_hash_extra_repos conf in
-        let%lwt () =
+        let* () = update_docker_image conf in
+        let* (opam_repo, opam_repo_commit) = get_commit_hash_default conf in
+        let* extra_repos = get_commit_hash_extra_repos conf in
+        let* () =
           (* TODO: Add a mutex system to make sure nobody else is using docker
              at the same time (e.g. another opam-health-check instance) *)
           match%lwt
@@ -623,33 +623,33 @@ let run ~debug ~on_finished ~conf cache workdir =
         let switches = List.map (fun switch -> (switch, get_dockerfile ~conf ~opam_repo ~opam_repo_commit ~extra_repos switch)) switches in
         begin match switches with
         | switch::_ ->
-            let%lwt old_logdir = Oca_server.Cache.get_logdirs cache in
+            let* old_logdir = Oca_server.Cache.get_logdirs cache in
             let compressed = Server_configfile.enable_logs_compression conf in
             let old_logdir = List.head_opt old_logdir in
             let new_logdir = Server_workdirs.new_logdir ~compressed ~hash:opam_repo_commit ~start_time workdir in
-            let%lwt () = Server_workdirs.init_base_jobs ~switches:switches' new_logdir in
+            let* () = Server_workdirs.init_base_jobs ~switches:switches' new_logdir in
             let number_of_jobs = Server_configfile.processes conf in
             let pool = Lwt_pool.create number_of_jobs (fun () -> Lwt.return_unit) in
             let max_ram_per_job = get_max_ram_per_job ~number_of_jobs in
-            let%lwt pkgs = Lwt_list.map_s (get_pkgs ~debug ~max_ram_per_job ~stderr ~conf) switches in
+            let* pkgs = Lwt_list.map_s (get_pkgs ~debug ~max_ram_per_job ~stderr ~conf) switches in
             let pkgs = Pkg_set.of_list (List.concat pkgs) in
-            let%lwt () = Oca_lib.timer_log timer stderr "Initialization" in
+            let* () = Oca_lib.timer_log timer stderr "Initialization" in
             let (_, jobs) = run_jobs ~conf ~max_ram_per_job ~pool ~stderr new_logdir switches pkgs in
             let (_, jobs) = get_metadata ~debug ~conf ~max_ram_per_job ~jobs ~pool ~stderr new_logdir switch pkgs in
-            let%lwt () = Lwt.join jobs in
-            let%lwt () = Oca_lib.timer_log timer stderr "Operation" in
-            let%lwt () = Oca_lib.write_line stderr "Finishing up…" in
-            let%lwt () = move_tmpdirs_to_final ~switches:switches' new_logdir workdir in
-            let%lwt () = on_finished workdir in
-            let%lwt () = trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf in
+            let* () = Lwt.join jobs in
+            let* () = Oca_lib.timer_log timer stderr "Operation" in
+            let* () = Oca_lib.write_line stderr "Finishing up…" in
+            let* () = move_tmpdirs_to_final ~switches:switches' new_logdir workdir in
+            let* () = on_finished workdir in
+            let* () = trigger_slack_webhooks ~stderr ~old_logdir ~new_logdir conf in
             Oca_lib.timer_log timer stderr "Clean up"
         | [] ->
             Oca_lib.write_line stderr "No switches."
         end
       with
       | exc ->
-          let%lwt () = Oca_lib.write_line stderr ("Exception: "^Printexc.to_string exc^".") in
-          let%lwt () = Oca_lib.write stderr (Printexc.get_backtrace ()) in
+          let* () = Oca_lib.write_line stderr ("Exception: "^Printexc.to_string exc^".") in
+          let* () = Oca_lib.write stderr (Printexc.get_backtrace ()) in
           Lwt.return (prerr_endline "The current run failed unexpectedly. Please check the latest log using: opam-health-check log")
     end
   end (fun () -> run_locked := false; Lwt.return_unit) end;

--- a/server/backend/dune
+++ b/server/backend/dune
@@ -1,6 +1,5 @@
 (library
   (name backend)
-  (preprocess (pps lwt_ppx))
   (libraries
     unix
     oca_lib

--- a/server/dune
+++ b/server/dune
@@ -1,7 +1,6 @@
 (executable
   (name main)
   (public_name opam-health-serve)
-  (preprocess (pps lwt_ppx))
   (libraries backend lwt.unix containers cmdliner oca_server memtrace))
 
 (rule

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 open Intf
 
 module Opams_cache = Map.Make (String)

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -180,7 +180,7 @@ let filter_pkg ~logsearch query (acc, last) pkg =
     | None -> true
     | Some last -> not (String.equal (Pkg.name pkg) (Pkg.name last))
   in
-  match%lwt must_show_package ~logsearch query ~is_latest pkg with
+  let* lwt = must_show_package ~logsearch query ~is_latest pkg in match lwt with
   | true -> Lwt.return (pkg :: acc, Some pkg)
   | false -> Lwt.return (acc, Some pkg)
 
@@ -220,7 +220,7 @@ let get_html ~conf self query logdir =
 
 let get_latest_logdir self =
   let* self = !self in
-  match%lwt self.logdirs with
+  let* lwt = self.logdirs in match lwt with
   | [] -> Lwt.return None
   | logdir::_ -> Lwt.return (Some logdir)
 
@@ -274,7 +274,7 @@ let get_html_run_list self =
 let get_json_latest_packages self =
   let* self = !self in
   let* json =
-    let* pkgs = match%lwt self.logdirs with
+    let* pkgs = let* lwt = self.logdirs in match lwt with
       | [] -> Lwt.return []
       | logdir::_ ->
           let* pkgs = self.pkgs in

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -84,27 +84,27 @@ let clear_and_init r_self ~pkgs ~compilers ~logdirs ~opams ~revdeps =
   let self = create_data () in
   let mvar = Lwt_mvar.create_empty () in
   r_self := begin
-    let%lwt () = Lwt_mvar.take mvar in
+    let* () = Lwt_mvar.take mvar in
     Lwt.return self
   end;
   self.opams <- opams ();
   self.revdeps <- revdeps ();
   self.logdirs <- logdirs ();
   self.compilers <- begin
-    let%lwt logdirs = self.logdirs in
+    let* logdirs = self.logdirs in
     Lwt_list.map_s (fun logdir ->
-      let%lwt c = compilers logdir in
+      let* c = compilers logdir in
       Lwt.return (logdir, c)
     ) logdirs
   end;
   self.pkgs <- begin
-    let%lwt compilers = self.compilers in
+    let* compilers = self.compilers in
     Lwt_list.mapi_s (fun i (logdir, compilers) ->
-      let%lwt p =
+      let* p =
         let aux () = pkgs ~compilers logdir in
         match i with
         | 0 | 1 ->
-            let%lwt p = aux () in
+            let* p = aux () in
             Lwt.return (Prefetched p)
         | _ ->
             Lwt.return (Recompute aux)
@@ -112,19 +112,19 @@ let clear_and_init r_self ~pkgs ~compilers ~logdirs ~opams ~revdeps =
       Lwt.return (logdir, p)
     ) compilers
   end;
-  let%lwt _ = self.opams in
-  let%lwt _ = self.revdeps in
-  let%lwt _ = self.logdirs in
-  let%lwt _ = self.compilers in
-  let%lwt () = Lwt_mvar.put mvar () in
-  let%lwt _ = self.pkgs in
+  let* _ = self.opams in
+  let* _ = self.revdeps in
+  let* _ = self.logdirs in
+  let* _ = self.compilers in
+  let* () = Lwt_mvar.put mvar () in
+  let* _ = self.pkgs in
   Oca_lib.timer_log timer Lwt_unix.stderr "Cache prefetching"
 
 let is_deprecated flag =
   String.equal (OpamTypesBase.string_of_pkg_flag flag) "deprecated"
 
 let (>>&&) x f =
-  let%lwt x = x in
+  let* x = x in
   if x then f () else Lwt.return_false
 
 let must_show_package ~logsearch query ~is_latest pkg =
@@ -170,7 +170,7 @@ let must_show_package ~logsearch query ~is_latest pkg =
   end >>&& begin fun () ->
     match snd query.Html.logsearch with
     | Some _ ->
-        let%lwt logsearch = logsearch in
+        let* logsearch = logsearch in
         Lwt.return (List.exists (Pkg.equal pkg) logsearch)
     | None -> Lwt.return_true
   end
@@ -190,7 +190,7 @@ let get_logsearch ~query ~logdir =
   | _, None -> Lwt.return []
   | regexp, Some (_, comp) ->
       let switch = Compiler.to_string comp in
-      let%lwt searches = Server_workdirs.logdir_search ~switch ~regexp logdir in
+      let* searches = Server_workdirs.logdir_search ~switch ~regexp logdir in
       List.filter_map (fun s ->
         match String.split_on_char '/' s with
         | [_switch; _state; full_name] -> Some (Pkg.create ~full_name ~instances:[] ~opam:OpamFile.OPAM.empty ~revdeps:(-1))
@@ -207,77 +207,77 @@ let get_or_recompute = function
 
 let get_html ~conf self query logdir =
   let aux ~logdir pkgs =
-    let%lwt pkgs = pkgs in
+    let* pkgs = pkgs in
     let logsearch = get_logsearch ~query ~logdir in
-    let%lwt (pkgs, _) = Lwt_list.fold_left_s (filter_pkg ~logsearch query) ([], None) (List.rev pkgs) in
+    let* (pkgs, _) = Lwt_list.fold_left_s (filter_pkg ~logsearch query) ([], None) (List.rev pkgs) in
     let pkgs = if query.Html.sort_by_revdeps then List.sort revdeps_cmp pkgs else pkgs in
     let html = Html.get_html ~logdir ~conf query pkgs in
     Lwt.return html
   in
-  let%lwt pkgs = self.pkgs in
+  let* pkgs = self.pkgs in
   let pkgs = List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs in
   aux ~logdir (get_or_recompute pkgs)
 
 let get_latest_logdir self =
-  let%lwt self = !self in
+  let* self = !self in
   match%lwt self.logdirs with
   | [] -> Lwt.return None
   | logdir::_ -> Lwt.return (Some logdir)
 
 let get_html ~conf self query logdir =
-  let%lwt self = !self in
+  let* self = !self in
   get_html ~conf self query logdir
 
 let get_logdirs self =
-  let%lwt self = !self in
+  let* self = !self in
   self.logdirs
 
 let get_pkgs ~logdir self =
-  let%lwt self = !self in
-  let%lwt pkgs = self.pkgs in
+  let* self = !self in
+  let* pkgs = self.pkgs in
   get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs)
 
 let get_compilers ~logdir self =
-  let%lwt self = !self in
-  let%lwt compilers = self.compilers in
+  let* self = !self in
+  let* compilers = self.compilers in
   Lwt.return (List.assoc ~eq:Server_workdirs.logdir_equal logdir compilers)
 
 let get_opam self k =
-  let%lwt self = !self in
-  let%lwt opams = self.opams in
+  let* self = !self in
+  let* opams = self.opams in
   Lwt.return (Option.get_or ~default:OpamFile.OPAM.empty (Opams_cache.find_opt k opams))
 
 let get_revdeps self k =
-  let%lwt self = !self in
-  let%lwt revdeps = self.revdeps in
+  let* self = !self in
+  let* revdeps = self.revdeps in
   Lwt.return (Option.get_or ~default:(-1) (Revdeps_cache.find_opt k revdeps))
 
 let get_html_diff ~conf ~old_logdir ~new_logdir self =
-  let%lwt old_pkgs = get_pkgs ~logdir:old_logdir self in
-  let%lwt new_pkgs = get_pkgs ~logdir:new_logdir self in
+  let* old_pkgs = get_pkgs ~logdir:old_logdir self in
+  let* new_pkgs = get_pkgs ~logdir:new_logdir self in
   generate_diff old_pkgs new_pkgs |>
   Html.get_diff ~conf ~old_logdir ~new_logdir |>
   Lwt.return
 
 let get_html_diff_list self =
-  let%lwt self = !self in
-  let%lwt pkgs = self.pkgs in
+  let* self = !self in
+  let* pkgs = self.pkgs in
   Oca_lib.list_map_cube (fun (new_logdir, _) (old_logdir, _) -> (old_logdir, new_logdir)) pkgs |>
   Html.get_diff_list |>
   Lwt.return
 
 let get_html_run_list self =
-  let%lwt self = !self in
-  let%lwt pkgs = self.pkgs in
+  let* self = !self in
+  let* pkgs = self.pkgs in
   Lwt.return (Html.get_run_list (List.map fst pkgs))
 
 let get_json_latest_packages self =
-  let%lwt self = !self in
-  let%lwt json =
-    let%lwt pkgs = match%lwt self.logdirs with
+  let* self = !self in
+  let* json =
+    let* pkgs = match%lwt self.logdirs with
       | [] -> Lwt.return []
       | logdir::_ ->
-          let%lwt pkgs = self.pkgs in
+          let* pkgs = self.pkgs in
           get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs)
     in
     let json = Json.pkgs_to_json pkgs in

--- a/server/lib/dune
+++ b/server/lib/dune
@@ -1,7 +1,6 @@
 (library
   (name oca_server)
   (modules_without_implementation backend_intf)
-  (preprocess (pps lwt_ppx))
   (libraries
     unix
     lwt

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 module Make (Backend : Backend_intf.S) = struct
   let serv_text ~content_type body =
     let headers = Cohttp.Header.init_with "Content-Type" content_type in
@@ -154,8 +156,11 @@ module Make (Backend : Backend_intf.S) = struct
 
   let callback ~debug ~conf backend conn req body =
     (* TODO: Try to understand why it wouldn't do anything before when this was ~on_exn *)
-    try%lwt callback ~conf backend conn req body with
-    | e ->
+    Lwt.catch
+      begin fun () ->
+        callback ~conf backend conn req body
+      end
+      begin fun e ->
         if debug then begin
           let uri = Uri.to_string (Cohttp.Request.uri req) in
           let e = Printexc.to_string e in
@@ -163,6 +168,7 @@ module Make (Backend : Backend_intf.S) = struct
           prerr_endline (Printexc.get_backtrace ());
         end;
         Lwt.fail e
+      end
 
   let tcp_server port callback =
     Cohttp_lwt_unix.Server.create

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -38,7 +38,7 @@ module Make (Backend : Backend_intf.S) = struct
       end logsearch (Uri.get_query_param uri "logsearch_comp")
     in
     let logsearch = (option_to_string logsearch, logsearch') in
-    let%lwt available_compilers = Cache.get_compilers ~logdir Backend.cache in
+    let* available_compilers = Cache.get_compilers ~logdir Backend.cache in
     let compilers = match compilers with
       | [] -> available_compilers
       | compilers -> List.map Intf.Compiler.from_string compilers
@@ -76,7 +76,7 @@ module Make (Backend : Backend_intf.S) = struct
     | path -> filter_path (Fpath.segs (Fpath.v path))
 
   let get_logdir name =
-    let%lwt logdirs = Cache.get_logdirs Backend.cache in
+    let* logdirs = Cache.get_logdirs Backend.cache in
     Lwt.return (
       List.find_opt (fun logdir ->
         String.equal (Server_workdirs.get_logdir_name logdir) name
@@ -84,7 +84,7 @@ module Make (Backend : Backend_intf.S) = struct
     )
 
   let callback ~conf backend _conn req body_NOT_USED =
-    let%lwt () = Cohttp_lwt.Body.drain_body body_NOT_USED in
+    let* () = Cohttp_lwt.Body.drain_body body_NOT_USED in
     let uri = Cohttp.Request.uri req in
     let get_log ~logdir ~comp ~state ~pkg =
       match%lwt get_logdir logdir with
@@ -109,24 +109,24 @@ module Make (Backend : Backend_intf.S) = struct
                to finish. Please look at the documentation to learn how to \
                start it.\n"
         | Some logdir ->
-            let%lwt query = parse_raw_query logdir uri in
-            let%lwt html = Cache.get_html ~conf Backend.cache query logdir in
+            let* query = parse_raw_query logdir uri in
+            let* html = Cache.get_html ~conf Backend.cache query logdir in
             serv_text ~content_type:"text/html" html
         end
     | ["run"] ->
-        let%lwt html = Cache.get_html_run_list Backend.cache in
+        let* html = Cache.get_html_run_list Backend.cache in
         serv_text ~content_type:"text/html" html
     | ["run";logdir] ->
         begin match%lwt get_logdir logdir with
         | None ->
             Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
         | Some logdir ->
-            let%lwt query = parse_raw_query logdir uri in
-            let%lwt html = Cache.get_html ~conf Backend.cache query logdir in
+            let* query = parse_raw_query logdir uri in
+            let* html = Cache.get_html ~conf Backend.cache query logdir in
             serv_text ~content_type:"text/html" html
         end
     | ["diff"] ->
-        let%lwt html = Cache.get_html_diff_list Backend.cache in
+        let* html = Cache.get_html_diff_list Backend.cache in
         serv_text ~content_type:"text/html" html
     | ["diff"; range] ->
         let (old_logdir, new_logdir) = match String.split_on_char '.' range with
@@ -141,13 +141,13 @@ module Make (Backend : Backend_intf.S) = struct
             | None ->
                 Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
             | Some new_logdir ->
-                let%lwt html = Cache.get_html_diff ~conf ~old_logdir ~new_logdir Backend.cache in
+                let* html = Cache.get_html_diff ~conf ~old_logdir ~new_logdir Backend.cache in
                 serv_text ~content_type:"text/html" html
         end
     | ["log"; logdir; comp; state; pkg] ->
         get_log ~logdir ~comp ~state ~pkg
     | ["api"; "v1"; "latest"; "packages"] ->
-        let%lwt json = Cache.get_json_latest_packages Backend.cache in
+        let* json = Cache.get_json_latest_packages Backend.cache in
         serv_text ~content_type:"application/json" json
     | _ ->
         Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
@@ -171,12 +171,12 @@ module Make (Backend : Backend_intf.S) = struct
 
   let main ~debug ~workdir =
     Printexc.record_backtrace debug;
-    let%lwt cwd = Lwt_unix.getcwd () in
+    let* cwd = Lwt_unix.getcwd () in
     let workdir = Server_workdirs.create ~cwd ~workdir in
-    let%lwt () = Server_workdirs.init_base workdir in
+    let* () = Server_workdirs.init_base workdir in
     let conf = Server_configfile.from_workdir workdir in
     let port = Server_configfile.port conf in
-    let%lwt (backend, backend_task) = Backend.start ~debug conf workdir in
+    let* (backend, backend_task) = Backend.start ~debug conf workdir in
     Lwt.join [
       tcp_server port (callback ~debug ~conf backend);
       backend_task ();

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -87,13 +87,13 @@ module Make (Backend : Backend_intf.S) = struct
     let* () = Cohttp_lwt.Body.drain_body body_NOT_USED in
     let uri = Cohttp.Request.uri req in
     let get_log ~logdir ~comp ~state ~pkg =
-      match%lwt get_logdir logdir with
+      let* lwt = get_logdir logdir in match lwt with
       | None ->
           Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
       | Some logdir ->
           let comp = Intf.Compiler.from_string comp in
           let state = Intf.State.from_string state in
-          match%lwt Backend.get_log backend ~logdir ~comp ~state ~pkg with
+          let* lwt = Backend.get_log backend ~logdir ~comp ~state ~pkg in match lwt with
           | None ->
               Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
           | Some log ->
@@ -102,7 +102,7 @@ module Make (Backend : Backend_intf.S) = struct
     in
     match path_from_uri uri with
     | [] ->
-        begin match%lwt Cache.get_latest_logdir Backend.cache with
+        begin let* lwt = Cache.get_latest_logdir Backend.cache in match lwt with
         | None ->
             serv_text ~content_type:"text/plain"
               "opam-health-check: no run exist, please wait for the first run \
@@ -117,7 +117,7 @@ module Make (Backend : Backend_intf.S) = struct
         let* html = Cache.get_html_run_list Backend.cache in
         serv_text ~content_type:"text/html" html
     | ["run";logdir] ->
-        begin match%lwt get_logdir logdir with
+        begin let* lwt = get_logdir logdir in match lwt with
         | None ->
             Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
         | Some logdir ->
@@ -133,11 +133,11 @@ module Make (Backend : Backend_intf.S) = struct
           | [old_logdir; ""; new_logdir] -> (old_logdir, new_logdir)
           | _ -> assert false
         in
-        begin match%lwt get_logdir old_logdir with
+        begin let* lwt = get_logdir old_logdir in match lwt with
         | None ->
             Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
         | Some old_logdir ->
-            match%lwt get_logdir new_logdir with
+            let* lwt = get_logdir new_logdir in match lwt with
             | None ->
                 Cohttp_lwt_unix.Server.respond ~body:`Empty ~status:`Not_found ()
             | Some new_logdir ->


### PR DESCRIPTION
While waiting for https://github.com/kit-ty-kate/opam-health-check-ng/pull/7 to work, we can do that to at least move forward a little.
When it is time to move to miou it should be be easy to replace `let*` by the identity (`let ( let* ) x f = f x`) 